### PR TITLE
 Time each iteration to minimise impact of GC on benchmarks

### DIFF
--- a/pony_bench.pony
+++ b/pony_bench.pony
@@ -12,6 +12,10 @@ actor PonyBench
 
   new create(env: Env, list: BenchmarkList) =>
     _env = consume env
+    ifdef debug then
+      _env.err.print("***WARNING*** Benchmark was built as DEBUG. Timings may be affected.")
+    end
+
     _output_manager =
       if _env.args.contains("-csv", {(a, b) => a == b })
       then _CSVOutput(_env)


### PR DESCRIPTION
Prior to this commit, the timing included all activity from before
the first iteration to right after the last iteration including
any GC time and other time spent between `_run_iteration` behavior
calls.

This commit changes the logic to time each iteration individually
and accumulate the times of all iterations to avoid including any
time spent on GC and other things for synchronous benchmarks. A
similar change was made to asynchronous benchmarks, however those
are not guaranteed to exclude GC time due to the fact that the
actual async benchmark logic is likely to involve other actors
over which we have no control.


Additionally, add warning printed to stderr when built as debug.